### PR TITLE
fix typo add() -> multiple()

### DIFF
--- a/docs/lec11.md
+++ b/docs/lec11.md
@@ -18,7 +18,7 @@ int multiple(int x, int y) {
 int z = multiple(3, 4);
 ```
 
-In the simple example above, our code continues executing after, and only after `add()` completes.
+In the simple example above, our code continues executing after, and only after `multiple()` completes.
 
 If a method takes a long time to run, however, the execution will delay the execution of subsequent methods, and maybe undesirable.
 

--- a/docs/lec11.md
+++ b/docs/lec11.md
@@ -159,7 +159,7 @@ In `CompletableFuture`, the method that makes `CompletableFuture` a functor is t
 <U> CompletableFuture<U> thenApply(Function<? super T,? extends U> func)
 ```
 
-The method `thenApply` is similar to `thenAccept`, except that instead of a `Consumer`, the callback that gets invoked when the asynchronous task completes is a `Function.  
+The method `thenApply` is similar to `thenAccept`, except that instead of a `Consumer`, the callback that gets invoked when the asynchronous task completes is a `Function`.  
 
 There are other variations: 
 

--- a/docs/lec9.md
+++ b/docs/lec9.md
@@ -232,7 +232,7 @@ It is helpful to understand the type first:
 
 - `T` is the type of the elements we are collecting
 - `R` is the type of the result of the collection
-- `A` is the type of the partial result from the accumulator (ala reduction)
+- `A` is the type of the partial result from the accumulator (aka reduction)
 
 Each of these methods shown above in the `Collector` is returning a function that will be invoked by the `collect` method.  Except combiner, the other three methods are rather straightforward: the `supplier` supplies a "container" of type `A` for the `accumulator` to accumulate into, and finally the `finisher` converts the container into the result of type `R`.
 


### PR DESCRIPTION
I think the lecture notes is trying to say multiple() method instead of add() since add() doesn't exist in the sample above.

`Function -> `Function`