### PR TITLE
update the correct definition for anyMatch

### DIFF
--- a/docs/lec8.md
+++ b/docs/lec8.md
@@ -331,7 +331,7 @@ Here are more useful terminal operations:
 
 - *`noneMatch`* return true if none of the elements pass the given predicate.
 - *`allMatch`* return true if every element passes the given predicate.
-- *`anyMatch`* return true if no elements passes the given predicate.
+- *`anyMatch`* return true if any of  elements passes the given predicate.
 
 ### Example 1: Is this a prime?
 

--- a/docs/lec8.md
+++ b/docs/lec8.md
@@ -331,7 +331,7 @@ Here are more useful terminal operations:
 
 - *`noneMatch`* return true if none of the elements pass the given predicate.
 - *`allMatch`* return true if every element passes the given predicate.
-- *`anyMatch`* return true if any of  elements passes the given predicate.
+- *`anyMatch`* return true if any of the elements passes the given predicate.
 
 ### Example 1: Is this a prime?
 


### PR DESCRIPTION
The correct definition for Stream::anyMatch() is

```
anyMatch(Predicate<? super T> predicate)Returns whether any elements of this stream match the provided predicate.
```
The lecture notes say "anyMatch return true if no elements passes the given predicate" which can be confusing with noneMatch()

